### PR TITLE
Fix #1: Use net-browserify-stub in the browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,1 @@
-if (System._nodeRequire)
-  module.exports = System._nodeRequire('net');
-else
-  throw "Node net module not supported in browsers.";
+module.exports = System._nodeRequire ? System._nodeRequire('net') : require('net-browserify-stub');

--- a/package.json
+++ b/package.json
@@ -1,3 +1,6 @@
 {
-  "registry": "npm"
+  "registry": "npm",
+  "dependencies": {
+    "net-browserify-stub": "0.0.1"
+  }
 }


### PR DESCRIPTION
This provides the isip\* functions. 

Back story/use case: I'm trying to use request/request which supposedly has intermittently worked with browserify. It uses tough-cookie which uses net but only for isip\* functions.

Ref: https://github.com/goinstant/tough-cookie/blob/c66bebadd634f4ff5d8a06519f9e0e4744986ab8/lib/cookie.js
